### PR TITLE
[#21] Tutor, Tutor찾기 API 설계

### DIFF
--- a/grapit-spring/src/main/java/edu/oak/grapitspring/tutor/FindTutorDTO.java
+++ b/grapit-spring/src/main/java/edu/oak/grapitspring/tutor/FindTutorDTO.java
@@ -1,0 +1,30 @@
+package edu.oak.grapitspring.tutor;
+
+import lombok.*;
+
+@Getter
+@Setter
+@ToString
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class FindTutorDTO {
+    private genderType gender;
+    private gradeType grade;
+    private rankingType ranking;
+
+    @Builder
+    public FindTutorDTO(genderType gender, gradeType grade, rankingType ranking) {
+        this.gender = gender;
+        this.grade = grade;
+        this.ranking = ranking;
+    }
+
+    public TutorEntity toEntity() {
+        return TutorEntity.builder()
+                .gender(gender)
+                .grade(grade)
+                .ranking(ranking)
+                .build();
+    }
+
+
+}

--- a/grapit-spring/src/main/java/edu/oak/grapitspring/tutor/MemoryTutorRepository.java
+++ b/grapit-spring/src/main/java/edu/oak/grapitspring/tutor/MemoryTutorRepository.java
@@ -1,0 +1,50 @@
+package edu.oak.grapitspring.tutor;
+
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Repository;
+
+import javax.persistence.EntityManager;
+import javax.persistence.PersistenceContext;
+import javax.persistence.TypedQuery;
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+@RequiredArgsConstructor
+@Slf4j
+public class MemoryTutorRepository implements TutorRepository {
+
+
+    @PersistenceContext
+    private final EntityManager em;
+
+    @Override
+    public Long insert(TutorEntity tutorEntity) {
+        em.persist(tutorEntity);
+        return tutorEntity.getTutorId();
+    }
+
+    @Override
+    public Optional<TutorEntity> findByTutorId(Long tutorId) {
+        return Optional.ofNullable(em.find(TutorEntity.class, tutorId));
+    }
+
+    @Override
+    public List<TutorEntity> findTutor(genderType gender, gradeType grade, rankingType ranking) {
+
+        String queryString = "select t from TutorEntity as t where t.grade = :grade and t.ranking = :ranking";
+        if (!gender.equals(genderType.BOTH)) {
+            queryString += " and t.gender = :gender";
+        }
+        TypedQuery<TutorEntity> query = em.createQuery(queryString, TutorEntity.class);
+        query.setParameter("grade", grade);
+        query.setParameter("ranking", ranking);
+        if (!gender.equals(genderType.BOTH)) {
+            query.setParameter("gender", gender);
+        }
+        return query.getResultList();
+
+    }
+}

--- a/grapit-spring/src/main/java/edu/oak/grapitspring/tutor/TutorEntity.java
+++ b/grapit-spring/src/main/java/edu/oak/grapitspring/tutor/TutorEntity.java
@@ -1,0 +1,41 @@
+package edu.oak.grapitspring.tutor;
+
+import lombok.*;
+
+import javax.persistence.*;
+
+@ToString
+@Entity
+@Getter
+@Setter
+@Table(name = "Tutor")
+//@Data
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class TutorEntity {
+
+    @Id
+    @GeneratedValue
+    private Long tutorId;
+    private String nickName;
+    private String email;
+    private String passwd;
+    @Enumerated(EnumType.STRING)
+    private genderType gender;
+    @Enumerated(EnumType.STRING)
+    private gradeType grade;
+    @Enumerated(EnumType.STRING)
+    private rankingType ranking;
+
+    @Builder
+    public TutorEntity(Long tutorId, String nickName, String email, String passwd, genderType gender,
+                       gradeType grade, rankingType ranking) {
+        this.tutorId = tutorId;
+        this.nickName = nickName;
+        this.email = email;
+        this.passwd = passwd;
+        this.gender = gender;
+        this.grade = grade;
+        this.ranking = ranking;
+    }
+
+}

--- a/grapit-spring/src/main/java/edu/oak/grapitspring/tutor/TutorFindController.java
+++ b/grapit-spring/src/main/java/edu/oak/grapitspring/tutor/TutorFindController.java
@@ -1,0 +1,27 @@
+package edu.oak.grapitspring.tutor;
+
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@Slf4j
+public class TutorFindController {
+
+    private final TutorFindService tutorFindService;
+
+    @GetMapping("/tutorfind")
+    public String tutorFind(@RequestBody TutorEntity tutorEntity) {
+        System.out.println("TutorFindController.tutorFind");
+        List<TutorEntity> findTutorList = tutorFindService.findTutor(tutorEntity.getGender(),
+                tutorEntity.getGrade(), tutorEntity.getRanking());
+
+        return "findTutorList";
+    }
+}

--- a/grapit-spring/src/main/java/edu/oak/grapitspring/tutor/TutorFindService.java
+++ b/grapit-spring/src/main/java/edu/oak/grapitspring/tutor/TutorFindService.java
@@ -1,0 +1,38 @@
+package edu.oak.grapitspring.tutor;
+
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Optional;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+public class TutorFindService {
+    private final TutorRepository tutorRepository;
+
+    public void save(TutorEntity tutorEntity) {
+        tutorRepository.insert(tutorEntity);
+    }
+
+    public Optional<TutorEntity> findByTutorId(Long tutorId) {
+        return tutorRepository.findByTutorId(tutorId);
+    }
+
+    public List<TutorEntity> findTutor(genderType gender,
+                                       gradeType grade,
+                                       rankingType ranking) {
+        System.out.println("TutorFindService.findByTutorGender");
+        List<TutorEntity> findTutorList = tutorRepository.findTutor(gender, grade, ranking);
+        log.info(findTutorList.toString());
+        if (findTutorList.size() == 0) {
+            System.out.println("원하는 선생님을 찾을 수 업습니다.");
+        }
+
+        return findTutorList;
+    }
+
+}

--- a/grapit-spring/src/main/java/edu/oak/grapitspring/tutor/TutorRepository.java
+++ b/grapit-spring/src/main/java/edu/oak/grapitspring/tutor/TutorRepository.java
@@ -1,0 +1,12 @@
+package edu.oak.grapitspring.tutor;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface TutorRepository {
+    Long insert(TutorEntity tutorEntity);
+
+    Optional<TutorEntity> findByTutorId(Long tutorId);
+
+    List<TutorEntity> findTutor(genderType gender, gradeType grade, rankingType ranking);
+}

--- a/grapit-spring/src/main/java/edu/oak/grapitspring/tutor/genderType.java
+++ b/grapit-spring/src/main/java/edu/oak/grapitspring/tutor/genderType.java
@@ -1,0 +1,6 @@
+package edu.oak.grapitspring.tutor;
+
+public enum genderType {
+    MAN, WOMAN, BOTH
+
+}

--- a/grapit-spring/src/main/java/edu/oak/grapitspring/tutor/gradeType.java
+++ b/grapit-spring/src/main/java/edu/oak/grapitspring/tutor/gradeType.java
@@ -1,0 +1,5 @@
+package edu.oak.grapitspring.tutor;
+
+public enum gradeType {
+    MIDDLE_1, MIDDLE_2, MIDDLE_3
+}

--- a/grapit-spring/src/main/java/edu/oak/grapitspring/tutor/rankingType.java
+++ b/grapit-spring/src/main/java/edu/oak/grapitspring/tutor/rankingType.java
@@ -1,0 +1,5 @@
+package edu.oak.grapitspring.tutor;
+
+public enum rankingType {
+    RANKING_D, RANKING_C, RANKING_B, RANKING_A
+}


### PR DESCRIPTION
gender, grade, ranking 3 가지 항목에 따른 선생님 매칭
gender의 경우 BOTH 선택 시 남자, 여자 선생님 모두 찾기 가능
 * 추 후 회원 가입 시 Tutor, Tutee 나눌 경우 Member 및 Tutor Entity 수정 예정

### Issue_number
[#21]

# Summary
 * 상단 커밋 내용 ( 총 3가지 분류로 튜터 매칭 ) 각 1개 씩 선택 가능
   - gender : MAN, WOMAN, BOTH  ( BOTH 선택 시 남자, 여자  둘 다 포함 )
   - grade : MIDDLE_1, MIDDLE_2, MIDDLE_3
   - ranking : GRADE_D, GRADE_C, GRADE_B, GRADE_A 
 * 중간에 비즈니스 로직이 필요하거나 필요 없는 경우 수정 해야 할 부분
  ( insert / findByTuturId)

# Check_List
필요없는 체크리스트는 제거해주세요
- [ ] Reviewer 등록
- [ ] Label 등록
- [ ] Commit Message 규칙 확인
